### PR TITLE
Removed Docker from ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,6 @@ go test -v
 
 ```
 
-### Deployment
-
-TODO:
-Docker container works for running the application, need to expose different ports and allow discovery on host network
 
 ### Contribution
 


### PR DESCRIPTION
Do we need to put the initial work descriptions in the work breakdown at the bottem?